### PR TITLE
5.14.24 Collison box and load assets

### DIFF
--- a/Start-Your-Editor/src/ImGuiEditorWindow.cpp
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.cpp
@@ -244,15 +244,47 @@ void ImGuiEditorWindow::collisionBoxControls(GameObject* gameObject) {
 
 		switch (collisionBoxShape) {
 		case 0: // Rectangle
-			ImGui::SliderFloat("Width", &collisionBoxWidth, 0.1f, 20.0f);
-			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.1f, 20.0f);
+			ImGui::SliderFloat("Width", &collisionBoxWidth, 0.0f, 20.0f);
+			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.0f, 20.0f);
 			break;
 		case 1: // Circle
-			ImGui::SliderFloat("Radius", &collisionBoxWidth, 0.1f, 20.0f); // Use Width as Radius
+			ImGui::SliderFloat("Radius", &collisionBoxWidth, 0.0f, 20.0f); // Use Width as Radius
 			break;
 		case 2: // Triangle
-			ImGui::SliderFloat("Base", &collisionBoxWidth, 0.1f, 20.0f);
-			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.1f, 20.0f);
+			ImGui::SliderFloat("Base", &collisionBoxWidth, 0.0f, 20.0f);
+			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.0f, 20.0f);
+			break;
+		}
+
+		// Visualization of the shape
+		ImGui::Text("Preview:");
+		ImVec2 canvas_pos = ImGui::GetCursorScreenPos(); // ImDrawList API uses screen coordinates!
+		ImVec2 canvas_size = ImVec2(200, 200); // Size of the canvas area
+		ImDrawList* draw_list = ImGui::GetWindowDrawList();
+		ImGui::InvisibleButton("canvas", canvas_size);
+		if (ImGui::IsItemHovered()) {
+			// Optional: Add details when hovering over the canvas
+		}
+
+		draw_list->AddRectFilled(canvas_pos, ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y), IM_COL32(50, 50, 50, 255)); // Background
+
+		const ImVec2 center = ImVec2(canvas_pos.x + canvas_size.x * 0.5f, canvas_pos.y + canvas_size.y * 0.5f);
+		const float radius = 70.0f; // Use a fixed radius for circle and vertices of the triangle
+
+		switch (collisionBoxShape) {
+		case 0: // Rectangle
+			draw_list->AddRect(ImVec2(center.x - collisionBoxWidth * 2, center.y - collisionBoxHeight * 2),
+				ImVec2(center.x + collisionBoxWidth * 2, center.y + collisionBoxHeight * 2),
+				IM_COL32(255, 255, 0, 255));
+			break;
+		case 1: // Circle
+			draw_list->AddCircle(center, collisionBoxWidth * 2, IM_COL32(255, 255, 0, 255));
+			break;
+		case 2: // Triangle
+			draw_list->AddTriangle(ImVec2(center.x, center.y - collisionBoxHeight * 2),
+				ImVec2(center.x - collisionBoxWidth * 2, center.y + collisionBoxHeight * 2),
+				ImVec2(center.x + collisionBoxWidth * 2, center.y + collisionBoxHeight * 2),
+				IM_COL32(255, 255, 0, 255));
 			break;
 		}
 
@@ -505,9 +537,18 @@ void ImGuiEditorWindow::assetSection()
 				if (ImGuiFileDialog::Instance()->IsOk()) {
 					std::string filePathName = ImGuiFileDialog::Instance()->GetFilePathName();
 					std::string fileName = ImGuiFileDialog::Instance()->GetCurrentFileName();
-					// load the selected asset using LoadTexture
-					ResourceManager::LoadTexture(filePathName.c_str(), true, fileName);
-					ImGui::Text("Loaded: %s", fileName.c_str());
+
+					// copy file to the texture folder
+					std::string destination = "./Start-Your-Engine/textures/" + fileName;
+					try {
+						std::filesystem::copy(filePathName, destination, std::filesystem::copy_options::overwrite_existing);
+						// load the copied asset into ResourceManager
+						ResourceManager::LoadTexture(destination.c_str(), true, fileName);
+						ImGui::Text("Loaded: %s", fileName.c_str());
+					}
+					catch (std::filesystem::filesystem_error& e) {
+						ImGui::Text("Failed to load asset: %s", e.what());
+					}
 				}
 				ImGuiFileDialog::Instance()->Close();
 			}
@@ -517,34 +558,50 @@ void ImGuiEditorWindow::assetSection()
 			ImGui::Separator();
 			ImGui::BeginChild("AssetsScrolling", ImVec2(0, 200), true, ImGuiWindowFlags_HorizontalScrollbar);
 
-			for (auto it = ResourceManager::Textures.begin(); it != ResourceManager::Textures.end();) {
-				ImGui::PushID(it->second.ID); // use the texture ID to push the ID
+			// update and display loaded assets dynamically
+			std::string texturePath = "./Start-Your-Engine/textures";
+			for (const auto& entry : std::filesystem::directory_iterator(texturePath)) {
+				if (entry.is_regular_file() && (entry.path().extension() == ".png" || entry.path().extension() == ".jpg")) {
+					std::string fileName = entry.path().filename().string();
+					std::string filePath = entry.path().string();
 
-				// display asset thumbnail
-				if (ImGui::ImageButton((void*)(intptr_t)it->second.ID, ImVec2(80, 80))) {
-					selectedAssetForPreview = it->first; // set the asset for preview
-				}
-				ImGui::PopID();
+					ImGui::PushID(filePath.c_str());
 
-				bool remove_item = false; // flag to determine if the item should be removed
-
-				// context menu for asset removal
-				if (ImGui::BeginPopupContextItem()) {
-					if (ImGui::MenuItem("Remove")) {
-						remove_item = true;
+					// check if the texture is loaded, if not, load it
+					if (ResourceManager::Textures.find(fileName) == ResourceManager::Textures.end()) {
+						ResourceManager::LoadTexture(filePath.c_str(), true, fileName);
 					}
-					ImGui::EndPopup();
-				}
+					auto textureID = ResourceManager::GetTexture(fileName).ID;
 
-				if (remove_item) {
-					glDeleteTextures(1, &it->second.ID); // delete OpenGL texture
-					it = ResourceManager::Textures.erase(it); // remove from ResourceManager and safely increment the iterator
-				}
-				else {
-					it++; // only increment the iterator if no item was removed
-				}
+					// display asset thumbnail
+					if (ImGui::ImageButton((void*)(intptr_t)textureID, ImVec2(80, 80))) {
+						selectedAssetForPreview = fileName; // Set the asset for preview
+					}
 
-				ImGui::SameLine(); // display assets in the same line (horizontally)
+					bool remove_item = false;
+
+					// context menu for asset removal
+					if (ImGui::BeginPopupContextItem()) {
+						if (ImGui::MenuItem("Remove")) {
+							remove_item = true;
+						}
+						ImGui::EndPopup();
+					}
+
+					if (remove_item) {
+						glDeleteTextures(1, &textureID); // delete OpenGL texture
+						ResourceManager::Textures.erase(fileName); // remove from ResourceManager
+						try {
+							std::filesystem::remove(filePath); // remove from the filesystem
+						}
+						catch (std::filesystem::filesystem_error& e) {
+							ImGui::Text("Failed to remove asset: %s", e.what());
+						}
+					}
+
+					ImGui::PopID();
+					ImGui::SameLine(); // display assets in the same line (horizontally)
+				}
 			}
 			ImGui::EndChild();
 

--- a/Start-Your-Editor/src/ImGuiEditorWindow.cpp
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.cpp
@@ -244,15 +244,15 @@ void ImGuiEditorWindow::collisionBoxControls(GameObject* gameObject) {
 
 		switch (collisionBoxShape) {
 		case 0: // Rectangle
-			ImGui::SliderFloat("Width", &collisionBoxWidth, 0.0f, 20.0f);
-			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.0f, 20.0f);
+			ImGui::SliderFloat("Width", &collisionBoxWidth, 0.1f, 20.0f);
+			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.1f, 20.0f);
 			break;
 		case 1: // Circle
-			ImGui::SliderFloat("Radius", &collisionBoxWidth, 0.0f, 20.0f); // Use Width as Radius
+			ImGui::SliderFloat("Radius", &collisionBoxWidth, 0.1f, 20.0f); // Use Width as Radius
 			break;
 		case 2: // Triangle
-			ImGui::SliderFloat("Base", &collisionBoxWidth, 0.0f, 20.0f);
-			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.0f, 20.0f);
+			ImGui::SliderFloat("Base", &collisionBoxWidth, 0.1f, 20.0f);
+			ImGui::SliderFloat("Height", &collisionBoxHeight, 0.1f, 20.0f);
 			break;
 		}
 
@@ -262,14 +262,9 @@ void ImGuiEditorWindow::collisionBoxControls(GameObject* gameObject) {
 		ImVec2 canvas_size = ImVec2(200, 200); // Size of the canvas area
 		ImDrawList* draw_list = ImGui::GetWindowDrawList();
 		ImGui::InvisibleButton("canvas", canvas_size);
-		if (ImGui::IsItemHovered()) {
-			// Optional: Add details when hovering over the canvas
-		}
 
 		draw_list->AddRectFilled(canvas_pos, ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y), IM_COL32(50, 50, 50, 255)); // Background
-
 		const ImVec2 center = ImVec2(canvas_pos.x + canvas_size.x * 0.5f, canvas_pos.y + canvas_size.y * 0.5f);
-		const float radius = 70.0f; // Use a fixed radius for circle and vertices of the triangle
 
 		switch (collisionBoxShape) {
 		case 0: // Rectangle

--- a/Start-Your-Editor/src/ImGuiEditorWindow.h
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.h
@@ -15,6 +15,8 @@
 #include "ImGuiFileDialog.h"
 #include "Framebuffer.h"
 #include "level.h"
+#include <filesystem>
+#include <fstream>
 
 class ImGuiEditorWindow
 {
@@ -49,9 +51,9 @@ public:
 
 	// Collision box
 	bool showCollisionBoxControls;
-	float collisionBoxWidth;
-	float collisionBoxHeight;
-	int collisionBoxShape; // 0 = Rectangle, 1 = Circle, 2 = Triangle
+	float collisionBoxWidth = 0.0f;
+	float collisionBoxHeight = 0.0f;
+	int collisionBoxShape = 0; // 0 = Rectangle, 1 = Circle, 2 = Triangle
 	void collisionBoxControls(GameObject* gameObject);
 private:
 	// content funtions for on render

--- a/Start-Your-Editor/src/ImGuiEditorWindow.h
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.h
@@ -51,8 +51,8 @@ public:
 
 	// Collision box
 	bool showCollisionBoxControls;
-	float collisionBoxWidth = 0.0f;
-	float collisionBoxHeight = 0.0f;
+	float collisionBoxWidth = 0.1f;
+	float collisionBoxHeight = 0.1f;
 	int collisionBoxShape = 0; // 0 = Rectangle, 1 = Circle, 2 = Triangle
 	void collisionBoxControls(GameObject* gameObject);
 private:

--- a/Start-Your-Editor/src/ImGuiEditorWindow.h
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.h
@@ -46,14 +46,12 @@ public:
 	void onRender();
 	void endRender();
 	void destroyWindow();
-	
+
 	// Collision box
 	bool showCollisionBoxControls;
-	int collisionBoxShape = 0;
-	std::vector<float> sideLengths;
-	float rotationDegrees = 0.0f;
-	float circleRadius = 0.0f;
-	int numSides = 3;
+	float collisionBoxWidth;
+	float collisionBoxHeight;
+	int collisionBoxShape; // 0 = Rectangle, 1 = Circle, 2 = Triangle
 	void collisionBoxControls(GameObject* gameObject);
 private:
 	// content funtions for on render
@@ -64,7 +62,7 @@ private:
 	void assetSection();
 
 	// helper methods for assetSection
-	void showAssetPreviewWindow(); 
+	void showAssetPreviewWindow();
 	// helper methods attributeSection
 	void objectDataSubsectionOfAttributeSection();
 	void physicsSubsectionOfAttributeSection();

--- a/Start-Your-Editor/src/ImGuiEditorWindow.h
+++ b/Start-Your-Editor/src/ImGuiEditorWindow.h
@@ -49,9 +49,11 @@ public:
 	
 	// Collision box
 	bool showCollisionBoxControls;
-	float collisionBoxWidth;
-	float collisionBoxHeight;
-	int collisionBoxShape; // 0 = Rectangle, 1 = Circle, 2 = Triangle
+	int collisionBoxShape = 0;
+	std::vector<float> sideLengths;
+	float rotationDegrees = 0.0f;
+	float circleRadius = 0.0f;
+	int numSides = 3;
 	void collisionBoxControls(GameObject* gameObject);
 private:
 	// content funtions for on render

--- a/imgui.ini
+++ b/imgui.ini
@@ -25,7 +25,7 @@ Collapsed=0
 
 [Window][scene tab ]
 Pos=203,19
-Size=1021,453
+Size=978,453
 Collapsed=0
 DockId=0x00000003,0
 
@@ -48,14 +48,14 @@ Collapsed=0
 DockId=0x00000007,0
 
 [Window][Game Object attributes tab ]
-Pos=1226,19
-Size=374,781
+Pos=1183,19
+Size=417,781
 Collapsed=0
 DockId=0x0000000C,0
 
 [Window][Assets tab ]
 Pos=0,474
-Size=1224,326
+Size=1181,326
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -968,12 +968,28 @@ Column 0  Sort=0v
 RefScale=13
 Column 0  Sort=0v
 
+[Table][0x3FE279EA,4]
+RefScale=13
+Column 0  Sort=0v
+
+[Table][0xF3D931CE,4]
+RefScale=13
+Column 0  Sort=0v
+
+[Table][0x2EA5A27C,4]
+RefScale=13
+Column 0  Sort=0v
+
+[Table][0x9CDA6A2A,4]
+RefScale=13
+Column 0  Sort=0v
+
 [Docking][Data]
 DockSpace             ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1600,781 Split=X
-  DockNode            ID=0x0000000B Parent=0x8B93E3BD SizeRef=1224,781 Split=Y
+  DockNode            ID=0x0000000B Parent=0x8B93E3BD SizeRef=1199,781 Split=Y
     DockNode          ID=0x00000009 Parent=0x0000000B SizeRef=1600,453 Split=X
       DockNode        ID=0x00000007 Parent=0x00000009 SizeRef=201,781 Selected=0x4752AFE1
-      DockNode        ID=0x00000008 Parent=0x00000009 SizeRef=1021,781 Split=Y
+      DockNode        ID=0x00000008 Parent=0x00000009 SizeRef=996,781 Split=Y
         DockNode      ID=0x00000001 Parent=0x00000008 SizeRef=1600,64 Selected=0x8116B37C
         DockNode      ID=0x00000002 Parent=0x00000008 SizeRef=1600,715 Split=X
           DockNode    ID=0x00000005 Parent=0x00000002 SizeRef=1238,800 Split=X Selected=0xDA443352
@@ -981,5 +997,5 @@ DockSpace             ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1600,781 Spl
             DockNode  ID=0x00000004 Parent=0x00000005 SizeRef=228,493 Selected=0x8F18975C
           DockNode    ID=0x00000006 Parent=0x00000002 SizeRef=360,800 Selected=0x194A8614
     DockNode          ID=0x0000000A Parent=0x0000000B SizeRef=1600,326 Selected=0x7DC222DD
-  DockNode            ID=0x0000000C Parent=0x8B93E3BD SizeRef=374,781 Selected=0xE86C9319
+  DockNode            ID=0x0000000C Parent=0x8B93E3BD SizeRef=417,781 Selected=0xE86C9319
 


### PR DESCRIPTION
- Deleted a line of redundant code from the collision method
- Improved the variables' initialization
- Debugged the inappropriate shape handling by rolling back the handling logic for simpler shapes
- Tried an alternative way to visualize the collision box
- Improved the load assets path logic to copy and paste the assets to the texture folder and then load them into our engine.